### PR TITLE
Fixing Softmax Response evaluation results

### DIFF
--- a/train.py
+++ b/train.py
@@ -569,7 +569,7 @@ def evaluate(testloader, model, use_cuda):
             sr_results[0].extend(list( -pred_logits.max(-1)[0]))
             sr_results[1].extend(list( predictions.eq(targets.data) ))
     abortion_scores, abortion_correct = torch.stack(abortion_results[0]), torch.stack(abortion_results[1])
-    sr_scores, sr_correct = torch.stack(abortion_results[0]), torch.stack(abortion_results[1])
+    sr_scores, sr_correct = torch.stack(sr_results[0]), torch.stack(sr_results[1])
     
     # Abstention Logit Results
     abortion_results = []
@@ -585,7 +585,7 @@ def evaluate(testloader, model, use_cuda):
 
     print("\Softmax\tResponse\tTest\tCoverage\tError")
     for idx, _ in enumerate(sr_results):
-        print('{:.0f},\t{:.2f},\t\t{:.3f}'.format(expected_coverage[idx], abortion_results[idx][0]*100., (1 - abortion_results[idx][1])*100))
+        print('{:.0f},\t{:.2f},\t\t{:.3f}'.format(expected_coverage[idx], sr_results[idx][0] * 100., (1 - sr_results[idx][1]) * 100))
 
     return
 


### PR DESCRIPTION
Hi!
I think there is an error in train.py, evaluate method, line 572.
The current code is:
sr_scores, sr_correct = torch.stack(abortion_results[0]), torch.stack(abortion_results[1])

If I am correct, it needs to be:
sr_scores, sr_correct = torch.stack(sr_results[0]), torch.stack(sr_results[1])

And in line 588:
Current:
        print('{:.0f},\t{:.2f},\t\t{:.3f}'.format(expected_coverage[idx], abortion_results[idx][0]*100., (1 - abortion_results[idx][1])*100))
Correct (?):
         print('{:.0f},\t{:.2f},\t\t{:.3f}'.format(expected_coverage[idx], sr_results[idx][0] * 100., (1 - sr_results[idx][1]) * 100))

I don´t know if these changes could affect your paper results.
Thanks,
Sandra Gómez-Gálvez